### PR TITLE
Build tweaks for GCCSDK autobuilder, bump to v0.2050b for new libssh2 build

### DIFF
--- a/nettle/!Nettle/Resources/France/Messages
+++ b/nettle/!Nettle/Resources/France/Messages
@@ -3,8 +3,8 @@
 
 AppName:Nettle
 AppPurpose:Client telnet arachnéen
-AppAuthor:© Développeurs de Nettle, 2000-2010
-AppVersion:v0.2043b (11 Avril 2010)
+AppAuthor:© Développeurs de Nettle, 2000-2023
+AppVersion:v0.2050b (28 Juillet 2023)
 
 Info:Info>
 Choices:Préférences...

--- a/nettle/!Nettle/Resources/Germany/Messages
+++ b/nettle/!Nettle/Resources/Germany/Messages
@@ -3,8 +3,8 @@
 
 AppName:Nettle
 AppPurpose:Telnet client
-AppAuthor:© Nettle Entwickler, 2000-2010
-AppVersion:v0.2043b (11 April 2010)
+AppAuthor:© Nettle Entwickler, 2000-2023
+AppVersion:v0.2050b (27 Juli 2023)
 
 Info:Info>
 Choices:Einstellungen...

--- a/nettle/!Nettle/Resources/UK/Messages
+++ b/nettle/!Nettle/Resources/UK/Messages
@@ -3,8 +3,8 @@
 
 AppName:Nettle
 AppPurpose:Telnet client
-AppAuthor:© Nettle developers, 2000-2010
-AppVersion:v0.2043b (11 April 2010)
+AppAuthor:© Nettle developers, 2000-2023
+AppVersion:v0.2050b (27 July 2023)
 
 Info:Info>
 Choices:Choices...

--- a/nettle/!RelSrc,fd7
+++ b/nettle/!RelSrc,fd7
@@ -1,5 +1,5 @@
 
-Set RelVer 0-2043b
+Set RelVer 0-2050b
 
 Echo Releasing Nettle <RelVer> *SOURCE CODE* ...
 

--- a/nettle/!Release,feb
+++ b/nettle/!Release,feb
@@ -1,5 +1,5 @@
 
-Set RelVer 0-2043b
+Set RelVer 0-2050b
 
 Echo Releasing Nettle <RelVer> ...
 

--- a/nettle/GNUmakefile
+++ b/nettle/GNUmakefile
@@ -2,8 +2,8 @@
 # Makefile for cross-compiling Nettle
 #
 
-CC = /home/riscos/gccsdk/cross/bin/arm-unknown-riscos-gcc
-NATIVE_CC = /usr/bin/gcc
+CC ?= /home/riscos/gccsdk/cross/bin/arm-unknown-riscos-gcc
+NATIVE_CC ?= /usr/bin/gcc
 CFLAGS = -c -D_BSD_SOURCE -std=c9x -Wall -mpoke-function-name -I/home/riscos/gccsdk/env/include
 CONFIG = -DWITH_SSH
 

--- a/nettle/GNUmakefile
+++ b/nettle/GNUmakefile
@@ -6,8 +6,11 @@ CC ?= /home/riscos/gccsdk/cross/bin/arm-unknown-riscos-gcc
 NATIVE_CC ?= /usr/bin/gcc
 CFLAGS = -c -D_BSD_SOURCE -std=c9x -Wall -mpoke-function-name -I/home/riscos/gccsdk/env/include
 CONFIG = -DWITH_SSH
+ELF2AIF ?= /home/riscos/gccsdk/cross/bin/elf2aif
 
 LIBS = -L/home/riscos/gccsdk/env/lib -lssh2 -lgcrypt -lgpg-error -lcrypto
+LIBS += -lz -ldl
+
 OBJS = chardefn.o choices.o dnslib.o globals.o init.o keyboard.o lineedit.o \
        main.o misc.o hotlist.o nettle.o process.o socket.o quit.o seln.o \
        wimp.o zapgen.o fortify.o sockwatch.o messages.o termlist.o url.o \
@@ -24,7 +27,7 @@ all:	!Nettle/!RunImage,ff8
 
 !Nettle/!RunImage,ff8: !Nettle/!RunImage,e1f
 	@echo " ELF2AIF:" $@
-	@/home/riscos/gccsdk/cross/bin/elf2aif $< $@
+	@$(ELF2AIF) $< $@
 	@rm !Nettle/!RunImage,e1f
 
 !Nettle/!RunImage,e1f: $(OBJS)


### PR DESCRIPTION
I've made some tweaks to both the GNUmakefile and the GCCSDK build script, which enables building with a new version of libssh2 (in this specific case, 1.10.0) rather than the 13 year old build from 2010.  In particular it avoids the need for a hardcoded GCCSDK at /home/riscos. I've also bumped the version number to 0.2050b in anticipation of a release of this version.  Hopefully this won't disturb the AMU or JFPaaS builds.

A test build may be found at:
https://www.chiark.greenend.org.uk/~theom/ephemeral/Nettle_0-2050b-1_arm.zip
- one user reports success with getting into a Raspberry Pi OS they couldn't before.

If this is acceptable I'll also commit the changes to the GCCSDK autobuilder recipe and push out a new build on riscos.info and its PackMan repository.